### PR TITLE
Jenga.Git: Improve the way git is invoked

### DIFF
--- a/src/Jenga/Git.hs
+++ b/src/Jenga/Git.hs
@@ -15,7 +15,7 @@ import           Jenga.Types
 
 import           Network.URI (parseURI, uriPath)
 
-import           System.Directory (createDirectoryIfMissing, doesDirectoryExist, withCurrentDirectory)
+import           System.Directory (createDirectoryIfMissing, doesDirectoryExist)
 import           System.FilePath ((</>), dropExtension)
 
 
@@ -59,13 +59,11 @@ split p =
 updateSubmodule :: FilePath -> StackGitRepo -> IO ()
 updateSubmodule dir gitrepo = do
   putStrLn $ "Updating submodule '" ++ dir ++ "' to commit " ++ T.unpack (T.take 10 $ sgrCommit gitrepo)
-  withCurrentDirectory dir $ do
-    gitUpdate
-    gitCheckoutCommit $ T.unpack (sgrCommit gitrepo)
+  gitUpdate dir
+  gitCheckoutCommit dir $ T.unpack (sgrCommit gitrepo)
 
 addSubmodule :: FilePath -> StackGitRepo -> IO ()
 addSubmodule dir gitrepo = do
   putStrLn $ "Adding submodule '" ++ dir ++ "' at commit " ++ T.unpack (T.take 10 $ sgrCommit gitrepo)
   gitAddSubmodule dir $ T.unpack (sgrUrl gitrepo)
-  withCurrentDirectory dir $
-    gitCheckoutCommit $ T.unpack (sgrCommit gitrepo)
+  gitCheckoutCommit dir $ T.unpack (sgrCommit gitrepo)

--- a/src/Jenga/Git/Command.hs
+++ b/src/Jenga/Git/Command.hs
@@ -20,14 +20,14 @@ gitAddSubmodule :: FilePath -> String -> IO ()
 gitAddSubmodule dest repo =
   git ["submodule", "add", "--force", repo, dest]
 
-gitCheckoutCommit :: String -> IO ()
-gitCheckoutCommit hash =
-  git ["checkout", hash]
+gitCheckoutCommit :: FilePath -> String -> IO ()
+gitCheckoutCommit dir hash =
+  git ["-C", dir, "checkout", hash]
 
-gitUpdate :: IO ()
-gitUpdate = do
-  git ["fetch"]
-  git ["submodule", "update"]
+gitUpdate :: FilePath -> IO ()
+gitUpdate dir = do
+  git ["-C", dir, "fetch"]
+  git ["-C", dir, "submodule", "update"]
 
 git :: [Argument] -> IO ()
 git args =


### PR DESCRIPTION
Previously submodules were updated and specific git commits checked out
by changing into the submodule and issuing the command. This requires
two system calls from Haskell code, the first to change into the directory
and the second to change back out.

The above scheme was dropped in favour of issing the commands in place
as:

    git -C <target-directory> <command>